### PR TITLE
Comment out lightGallery fixing a js error 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 .sass-cache
 bower_components
 atlassian-ide-plugin.xml
+.idea
 *.ipr
 *.iml
 *.iws

--- a/app/scripts/misc/kedavra.js
+++ b/app/scripts/misc/kedavra.js
@@ -61,7 +61,7 @@ jQuery(document).ready(function($) {
   var $harmonic = $('.harmonic .item');
   var $tooltip = $('.tooltipped');
   var $percentChart = $('.percent-chart');
-  var $lightGallery = $('.lightGallery');
+  // var $lightGallery = $('.lightGallery'); TODO: Throwing JS errors remove
 
   var $sidebarBtn = $('.sidebar-button');
   var $shareBar = $('.share-modal .bar');
@@ -368,7 +368,7 @@ jQuery(document).ready(function($) {
 
   /*Light Gallery (Lightbox)
    *******************************************/
-  $lightGallery.lightGallery({caption: true});
+  // $lightGallery.lightGallery({caption: true}); TODO: Throwing JS errors remove
 
   ///////////////////////////////////////////////////////////////////////
   /////////////////  Forms Validation and Styling  //////////////////////


### PR DESCRIPTION
Comment out lightGallery fixing a js error as lightGallery is no longer included in the bundle. This appears to clean up the last of the JS errors from the EU project.